### PR TITLE
Wrap long ScVal byte values so they don't overflow on mobile

### DIFF
--- a/contract/sc-val.scss
+++ b/contract/sc-val.scss
@@ -1,3 +1,5 @@
 .sc-val {
   line-height: 1;
+  // Break long byte/hash values so they don't overflow the screen on mobile.
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
Closes #12 

I hit this testing a passkey smart wallet on my phone. Opening a contract-creation tx on stellar.expert made the whole page scroll sideways. The culprit is the `__constructor` args: one of them is a long base64 `bytes` value (the wallet's public key) with no spaces to wrap on.

In `ScVal`, the `bytes` case renders into `<span className="condensed">`, which only sets letter-spacing and there's nothing telling it it can break. The other long-value cases (`str`, `sym`, `instance`) already use `word-break`. And because the op row is `display: flex; flex-wrap: nowrap`, that one unbreakable token keeps the row from shrinking, so it runs off the edge and drags the page with it.

The fix is one line on `.sc-val`: `overflow-wrap: anywhere`. I went with `anywhere` rather than `break-word` on purpose. It actually shrinks the element's min-content width, which is what lets the no-wrap flex row collapse back to the viewport. It inherits down to the byte/error spans, only kicks in when a token would otherwise overflow, and leaves short values looking exactly as they did. No JSX changes needed.

To check it, I reproduced the op row at a 375px width: it stretched the page to 688px before the change and sat at 375px (no overflow) after.